### PR TITLE
Add Github Action to Prioritize issues and apply labels and comments

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: 'bug'
+labels: 'Type:Bug'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feedback_report.md
+++ b/.github/ISSUE_TEMPLATE/feedback_report.md
@@ -2,7 +2,7 @@
 name: New feature or feedback
 about: Help us improve, suggest your feature
 title: ''
-labels: 'feedback'
+labels: 'Type:Feature'
 assignees: ''
 
 ---

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -27,7 +27,7 @@ configuration:
               reply: "${issueAuthor}, please add a Type:Bug/Type:Feature/Type:SupportRequest label as applicable."
           - addLabel:
               label: Needs-Info
-      - description: Update issue if Type label was assigned # removes Needs-Info if someone assigns a type label
+      - description: Update issue if Type label was assigned and removes Needs-Info
         triggerOnOwnActions: false
         if:
           - payloadType: Issues

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -1,10 +1,8 @@
-id: 
-name: GitOps.PullRequestIssueManagement
-description: GitOps.PullRequestIssueManagement primitive
-owner: 
+name: Issue Triage
+description: Assign label to new issues without a label
 resource: repository
 disabled: false
-where: 
+
 configuration:
   resourceManagementConfiguration:
     eventResponderTasks:
@@ -12,18 +10,113 @@ configuration:
         triggerOnOwnActions: false
         if:
           - payloadType: Issues
-          - isOpen
           - isAction:
               action: Opened
-          - hasLabel:
-              label: testing
+          - not:
+              or:
+                - hasLabel:
+                    label: Type:Bug
+                - hasLabel:
+                    label: Type:Feature
+                - hasLabel:
+                    label: Type:SupportRequest
         then:
           - addReply:
-              reply: "@${issueAuthor}, please add a Bug/Feature/SupportRequest label as
-                applicable."
+              reply: "${issueAuthor}, please add a Type:Bug/Type:Feature/Type:SupportRequest label as applicable."
           - addLabel:
               label: waitingForCustomer
           - addLabel:
               label: untriaged
-onFailure: 
-onSuccess: 
+      - description: Update issue if Type label was assigned # removes waitingForCustomer + untriaged if someone assigns a type label
+        triggerOnOwnActions: false
+        if:
+          - payloadType: Issues
+          - isOpen
+          - or:
+            - labelAdded:
+                label: Type:Bug
+            - labelAdded:
+                label: Type:Feature
+            - labelAdded:
+                label: Type:SupportRequest
+        then:
+          - if:
+              - hasLabel:
+                  label: untriaged
+            then:
+              - removeLabel:
+                  label: untriaged
+          - if:
+              - not:
+                  hasLabel:
+                    label: triaged
+            then:
+              - addLabel:
+                  label: triaged
+          - if:
+              - hasLabel:
+                  label: waitingForCustomer
+            then:
+              - removeLabel:
+                  label: waitingForCustomer
+      - description: Update issues that had recent activity
+        triggerOnOwnActions: false
+        if:
+          - payloadType: Issue_Comment
+          - isOpen
+          - or:
+            - isAction:
+                action: Created # create or update (applies to issue description too?)
+            - isAction:
+                action: Edited
+        then:
+          - if:
+              - hasLabel:
+                  label: stale
+            then:
+              - removeLabel:
+                  label: stale
+    scheduledSearches:
+      - description: search for issues that are waitingForCustomer and haven't got a response
+        frequencies:
+          - hourly:
+              hour: 1
+        filters:
+          - isOpen
+          - hasLabel:
+              label: waitingForCustomer
+          - noActivitySince:
+              days: 1
+        actions:
+          - addLabel:
+              label: stale
+      - description: close issues that are waitingForCustomer + stale for too long
+        frequencies:
+          - daily:
+              time: 20:45
+        filters:
+          - isOpen
+          - hasLabel:
+              label: waitingForCustomer
+          - hasLabel:
+              label: stale
+          - noActivitySince:
+              days: 1
+        actions:
+          - closeIssue
+          - addReply:
+              reply: "${issueAuthor}, this issue has been closed due to inactivity. Please feel free to reopen it if you have further information or questions."
+      - description: close issues that have not received any activity in 18 months
+        frequencies:
+          - daily:
+              time: 20:45
+        filters:
+          - isOpen
+          - noActivitySince:
+              days: 1
+          - hasLabel:
+              label: triageTest
+        actions:
+          - closeIssue
+          - addReply:
+              reply: "${issueAuthor}, this issue has been closed due to inactivity. Please feel free to reopen it if you have further information or questions."

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -21,10 +21,10 @@ configuration:
                 - hasLabel:
                     label: Type:Feature
                 - hasLabel:
-                    label: Type:SupportRequest
+                    label: Type:CustomerSupport
         then:
           - addReply:
-              reply: '${issueAuthor}, please add a `Type:Bug`/`Type:Feature`/`Type:SupportRequest` label as applicable.'
+              reply: '${issueAuthor}, please add a `Type:Bug`/`Type:Feature`/`Type:CustomerSupport` label as applicable.'
           - addLabel:
               label: needs-info
       - description: Update issue if Type label was assigned and removes needs-info
@@ -38,7 +38,7 @@ configuration:
             - labelAdded:
                 label: Type:Feature
             - labelAdded:
-                label: Type:SupportRequest
+                label: Type:CustomerSupport
         then:
           - if:
               - hasLabel:
@@ -90,7 +90,7 @@ configuration:
               reply: "${issueAuthor}, this issue will be closed soon due to inactivity. Please add more information to help us triage this issue."
           - addLabel:
               label: Stale
-      - description: Close lower priority issues that have not received any activity for 18 months
+      - description: Close lower priority non-Feature issues that have not received any activity for 18 months
         frequencies:
           - hourly:
               hour: 1
@@ -102,6 +102,8 @@ configuration:
               label: Priority:0
           - isNotLabeledWith:
               label: Priority:1
+          - isNotLabeledWith:
+              label: Type:Feature
           - isNotLabeledWith:
               label: DoNotClose
         actions:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -8,6 +8,28 @@ where:
 configuration:
   resourceManagementConfiguration:
     eventResponderTasks:
+      - description: Add bug type label for issues coming from VSCode
+        triggerOnOwnActions: false
+        if:
+          - payloadType: Issues
+          - isAction:
+              action: Opened
+          - bodyContains:
+              pattern: "Type: Bug"
+        then:
+          - addLabel:
+              label: Type:Bug
+      - description: Add feature type label for issues coming from VSCode
+        triggerOnOwnActions: false
+        if:
+          - payloadType: Issues
+          - isAction:
+              action: Opened
+          - bodyContains:
+              pattern: "Type: Feature Request"
+        then:
+          - addLabel:
+              label: Type:Feature
       - description: Check if a Type label is assigned to new issues
         triggerOnOwnActions: false
         if:
@@ -24,10 +46,10 @@ configuration:
                     label: Type:CustomerSupport
         then:
           - addReply:
-              reply: '${issueAuthor}, please add a `Type:Bug`/`Type:Feature`/`Type:CustomerSupport` label as applicable.'
+              reply: 'Team, please add a `Type:Bug`/`Type:Feature`/`Type:CustomerSupport` label as applicable.'
           - addLabel:
-              label: needs-info
-      - description: Update issue if Type label was assigned and removes needs-info
+              label: needs-typeLabel
+      - description: Update issue if Type label was assigned and removes needs-typeLabel
         triggerOnOwnActions: false
         if:
           - payloadType: Issues
@@ -42,16 +64,10 @@ configuration:
         then:
           - if:
               - hasLabel:
-                  label: needs-info
+                  label: needs-typeLabel
             then:
               - removeLabel:
-                  label: needs-info
-          - if:
-              - hasLabel:
-                  label: Stale
-            then:
-              - removeLabel:
-                  label: Stale
+                  label: needs-typeLabel
     scheduledSearches:
       - description: Close issues that are 'needs-info' and 'Stale', and have not received any activity for 1 week
         frequencies:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -26,8 +26,8 @@ configuration:
           - addReply:
               reply: '${issueAuthor}, please add a `Type:Bug`/`Type:Feature`/`Type:SupportRequest` label as applicable.'
           - addLabel:
-              label: Needs-Info
-      - description: Update issue if Type label was assigned and removes Needs-Info
+              label: needs-info
+      - description: Update issue if Type label was assigned and removes needs-info
         triggerOnOwnActions: false
         if:
           - payloadType: Issues
@@ -42,10 +42,10 @@ configuration:
         then:
           - if:
               - hasLabel:
-                  label: Needs-Info
+                  label: needs-info
             then:
               - removeLabel:
-                  label: Needs-Info
+                  label: needs-info
           - if:
               - hasLabel:
                   label: Stale
@@ -53,7 +53,7 @@ configuration:
               - removeLabel:
                   label: Stale
     scheduledSearches:
-      - description: Close issues that are 'Needs-Info' and 'Stale', and have not received any activity for 1 week
+      - description: Close issues that are 'needs-info' and 'Stale', and have not received any activity for 1 week
         frequencies:
           - hourly:
               hour: 1
@@ -62,7 +62,7 @@ configuration:
           - noActivitySince:
               days: 7
           - hasLabel:
-              label: Needs-Info
+              label: needs-info
           - hasLabel:
               label: Stale
           - isNotLabeledWith:
@@ -71,7 +71,7 @@ configuration:
           - addReply:
               reply: "${issueAuthor}, this issue has been closed due to inactivity over 2 weeks. Please feel free to reopen it if you have further information or questions."
           - closeIssue
-      - description: Warn the authors on issues that are 'Needs-Info', and have not received any activity for 1 week
+      - description: Warn the authors on issues that are 'needs-info', and have not received any activity for 1 week
         frequencies:
           - hourly:
               hour: 1
@@ -80,7 +80,7 @@ configuration:
           - noActivitySince:
               days: 7
           - hasLabel:
-              label: Needs-Info
+              label: needs-info
           - isNotLabeledWith:
               label: DoNotClose
           - isNotLabeledWith:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -1,8 +1,10 @@
-name: Issue Triage
-description: Assign label to new issues without a label
+id: 
+name: GitOps.PullRequestIssueManagement
+description: Issue management and triage
+owner: 
 resource: repository
 disabled: false
-
+where: 
 configuration:
   resourceManagementConfiguration:
     eventResponderTasks:
@@ -24,10 +26,8 @@ configuration:
           - addReply:
               reply: "${issueAuthor}, please add a Type:Bug/Type:Feature/Type:SupportRequest label as applicable."
           - addLabel:
-              label: waitingForCustomer
-          - addLabel:
-              label: untriaged
-      - description: Update issue if Type label was assigned # removes waitingForCustomer + untriaged if someone assigns a type label
+              label: Needs-Info
+      - description: Update issue if Type label was assigned # removes Needs-Info if someone assigns a type label
         triggerOnOwnActions: false
         if:
           - payloadType: Issues
@@ -42,81 +42,95 @@ configuration:
         then:
           - if:
               - hasLabel:
-                  label: untriaged
+                  label: Needs-Info
             then:
               - removeLabel:
-                  label: untriaged
+                  label: Needs-Info
           - if:
               - not:
                   hasLabel:
-                    label: triaged
+                    label: Stale
             then:
               - addLabel:
-                  label: triaged
-          - if:
-              - hasLabel:
-                  label: waitingForCustomer
-            then:
-              - removeLabel:
-                  label: waitingForCustomer
-      - description: Update issues that had recent activity
-        triggerOnOwnActions: false
-        if:
-          - payloadType: Issue_Comment
-          - isOpen
-          - or:
-            - isAction:
-                action: Created # create or update (applies to issue description too?)
-            - isAction:
-                action: Edited
-        then:
-          - if:
-              - hasLabel:
-                  label: stale
-            then:
-              - removeLabel:
-                  label: stale
+                  label: Stale
     scheduledSearches:
-      - description: search for issues that are waitingForCustomer and haven't got a response
+      - description: Close issues that are 'Needs-Info' and 'Stale', and have not received any activity for 1 week
+        frequencies:
+          - hourly:
+              hour: 1
+        filters:
+          - isOpen
+          - noActivitySince:
+              days: 7
+          - hasLabel:
+              label: Needs-Info
+          - hasLabel:
+              label: Stale
+          - isNotLabeledWith:
+              label: DoNotClose
+        actions:
+          - addReply:
+              reply: "${issueAuthor}, this issue has been closed due to inactivity over 2 weeks. Please feel free to reopen it if you have further information or questions."
+          - closeIssue
+      - description: Warn the authors on issues that are 'Needs-Info', and have not received any activity for 1 week
+        frequencies:
+          - hourly:
+              hour: 1
+        filters:
+          - isOpen
+          - noActivitySince:
+              days: 7
+          - hasLabel:
+              label: Needs-Info
+          - isNotLabeledWith:
+              label: DoNotClose
+          - isNotLabeledWith:
+              label: Stale
+        actions:
+          - addReply:
+              reply: "${issueAuthor}, this issue will be closed soon due to inactivity. Please add more information to help us triage this issue."
+          - addLabel:
+              label: Stale
+      - description: Close lower priority issues that have not received any activity for 18 months
+        frequencies:
+          - hourly:
+              hour: 1
+        filters:
+          - isOpen
+          - noActivitySince:
+              days: 548
+          - isNotLabeledWith:
+              label: Priority:0
+          - isNotLabeledWith:
+              label: Priority:1
+          - isNotLabeledWith:
+              label: DoNotClose
+        actions:
+          - closeIssue
+          - addReply:
+              reply: "${issueAuthor}, this issue has been closed due to inactivity for 18 months. Please feel free to reopen it if you have further information or questions."
+      - description: TEST - Reply to every testing issue
         frequencies:
           - hourly:
               hour: 1
         filters:
           - isOpen
           - hasLabel:
-              label: waitingForCustomer
-          - noActivitySince:
-              days: 1
+              label: testing
         actions:
-          - addLabel:
-              label: stale
-      - description: close issues that are waitingForCustomer + stale for too long
+          - addReply:
+              reply: "TEST - Scheduled runs work"
+      - description: TEST - reply to test issue and close
         frequencies:
-          - daily:
-              time: 20:45
+          - hourly:
+              hour: 1
         filters:
           - isOpen
           - hasLabel:
-              label: waitingForCustomer
-          - hasLabel:
-              label: stale
-          - noActivitySince:
-              days: 1
+              label: testing-close
         actions:
-          - closeIssue
           - addReply:
-              reply: "${issueAuthor}, this issue has been closed due to inactivity. Please feel free to reopen it if you have further information or questions."
-      - description: close issues that have not received any activity in 18 months
-        frequencies:
-          - daily:
-              time: 20:45
-        filters:
-          - isOpen
-          - noActivitySince:
-              days: 1
-          - hasLabel:
-              label: triageTest
-        actions:
+              reply: "TEST - Scheduled runs works and can close issues"
           - closeIssue
-          - addReply:
-              reply: "${issueAuthor}, this issue has been closed due to inactivity. Please feel free to reopen it if you have further information or questions."
+onFailure:
+onSuccess:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -163,6 +163,8 @@ configuration:
         actions:
           - addLabel:
               label: needs-typeLabel
+          - addReply:
+              reply: 'Team, please add a `Type:Bug`/`Type:Feature`/`Type:CustomerSupport` label as applicable.'
       - description: TEST - Reply to every testing issue
         frequencies:
           - hourly:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -24,7 +24,7 @@ configuration:
                     label: Type:SupportRequest
         then:
           - addReply:
-              reply: "${issueAuthor}, please add a Type:Bug/Type:Feature/Type:SupportRequest label as applicable."
+              reply: '${issueAuthor}, please add a `Type:Bug`/`Type:Feature`/`Type:SupportRequest` label as applicable.'
           - addLabel:
               label: Needs-Info
       - description: Update issue if Type label was assigned and removes Needs-Info
@@ -47,11 +47,10 @@ configuration:
               - removeLabel:
                   label: Needs-Info
           - if:
-              - not:
-                  hasLabel:
-                    label: Stale
+              - hasLabel:
+                  label: Stale
             then:
-              - addLabel:
+              - removeLabel:
                   label: Stale
     scheduledSearches:
       - description: Close issues that are 'Needs-Info' and 'Stale', and have not received any activity for 1 week

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -148,6 +148,21 @@ configuration:
           - closeIssue
           - addReply:
               reply: "${issueAuthor}, this issue has been closed due to inactivity for 18 months. Please feel free to reopen it if you have further information or questions."
+      - description: Add 'needs-typeLabel' to existing issues that do not have a Type label
+        frequencies:
+          - hourly:
+              hour: 1
+        filters:
+          - isOpen
+          - isNotLabeledWith:
+              label: Type:Bug
+          - isNotLabeledWith:
+              label: Type:Feature
+          - isNotLabeledWith:
+              label: Type:CustomerSupport
+        actions:
+          - addLabel:
+              label: needs-typeLabel
       - description: TEST - Reply to every testing issue
         frequencies:
           - hourly:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -16,6 +16,14 @@ configuration:
               action: Opened
           - bodyContains:
               pattern: "Type: Bug"
+          - not:
+              or:
+                - hasLabel:
+                    label: Type:Bug
+                - hasLabel:
+                    label: Type:Feature
+                - hasLabel:
+                    label: Type:CustomerSupport
         then:
           - addLabel:
               label: Type:Bug
@@ -27,6 +35,14 @@ configuration:
               action: Opened
           - bodyContains:
               pattern: "Type: Feature Request"
+          - not:
+              or:
+                - hasLabel:
+                    label: Type:Bug
+                - hasLabel:
+                    label: Type:Feature
+                - hasLabel:
+                    label: Type:CustomerSupport
         then:
           - addLabel:
               label: Type:Feature
@@ -44,6 +60,12 @@ configuration:
                     label: Type:Feature
                 - hasLabel:
                     label: Type:CustomerSupport
+          - not:
+              or:
+                - bodyContains:
+                    pattern: "Type: Bug"
+                - bodyContains:
+                    pattern: "Type: Feature Request"
         then:
           - addReply:
               reply: 'Team, please add a `Type:Bug`/`Type:Feature`/`Type:CustomerSupport` label as applicable.'

--- a/.github/workflows/prioritize-by-reactions.yaml
+++ b/.github/workflows/prioritize-by-reactions.yaml
@@ -1,0 +1,94 @@
+name: Prioritize Issues by Reactions
+
+on:
+  schedule:
+    - cron: '0 0 * * *'   # Runs once a day at midnight UTC
+  workflow_dispatch:       # Allows manual runs
+
+jobs:
+  prioritize:
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Install jq
+        run: sudo apt-get install -y jq
+
+      - name: Prioritize issues by reactions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: microsoft/vsmarketplace
+          BUG_HIGH: 10
+          BUG_MEDIUM: 5
+          FEATURE_MEDIUM: 25
+        run: |
+          issue_numbers=$(gh issue list -R "$REPO" --state open --json number -q '.[].number')
+
+          for ISSUE in $issue_numbers; do
+            echo "🔍 Checking Issue #$ISSUE"
+
+            # Get issue labels
+            labels=$(gh issue view $ISSUE -R $REPO --json labels -q '.labels[].name' | tr '\n' ' ')
+            echo "   Labels: $labels"
+
+            reactions=$(curl -s \
+              -H "Accept: application/vnd.github.squirrel-girl-preview+json" \
+              -H "Authorization: token $GH_TOKEN" \
+              https://api.github.com/repos/$REPO/issues/$ISSUE/reactions)
+
+            total=$(echo "$reactions" | jq 'length')
+
+            # Determine priority based on issue type
+            if echo "$labels" | grep -q "Type:Bug"; then
+              echo "   🐛 Bug issue detected"
+              if [ "$total" -ge "$BUG_HIGH" ]; then
+                priority="Priority:0"
+              elif [ "$total" -ge "$BUG_MEDIUM" ]; then
+                priority="Priority:1"
+              else
+                priority="Priority:2"
+              fi
+              echo "👉 Issue #$ISSUE has $total reactions — Assigning label: $priority"
+            elif echo "$labels" | grep -q "Type:Feature"; then
+              echo "   ✨ Feature request detected"
+              if [ "$total" -ge "$FEATURE_MEDIUM" ]; then
+                priority="Priority:1"
+                echo "👉 Issue #$ISSUE has $total reactions — Assigning label: $priority"
+              else
+                echo "👉 Issue #$ISSUE has $total reactions — Below threshold ($FEATURE_MEDIUM), no priority label assigned"
+                continue
+              fi
+            else
+              echo "👉 Issue #$ISSUE has no Type:Bug or Type:Feature label — Skipping prioritization"
+              continue
+            fi
+
+            # Get current Priority:* label (if any)
+            current_priority=$(gh issue view $ISSUE -R $REPO --json labels -q '.labels[].name' | grep '^Priority:' || echo "")
+
+            if [[ "$current_priority" != "$priority" ]]; then
+              # Check if current priority label was added by github-actions
+              if [[ -n "$current_priority" ]]; then
+                # Get the timeline events to see who added the current priority label
+                label_added_by=$(gh api repos/$REPO/issues/$ISSUE/timeline --paginate | jq -r --arg label "$current_priority" '.[] | select(.event == "labeled" and .label.name == $label) | .actor.login' | tail -1)
+
+                if [[ "$label_added_by" != "github-actions[bot]" ]]; then
+                  echo "   🚫 Priority label '$current_priority' was set by '$label_added_by' (not github-actions), skipping update"
+                  continue
+                fi
+
+                echo "   ⏹️  Removing old label: $current_priority (was set by github-actions)"
+                gh issue edit $ISSUE -R $REPO --remove-label "$current_priority"
+              fi
+
+              echo "   ➕ Adding new label: $priority"
+              gh issue edit $ISSUE -R $REPO --add-label "$priority"
+            else
+              echo "   ✅ Priority label already correct: $priority"
+            fi
+            echo ""
+          done

--- a/.github/workflows/prioritize-by-reactions.yaml
+++ b/.github/workflows/prioritize-by-reactions.yaml
@@ -59,8 +59,8 @@ jobs:
                 priority="Priority:1"
                 echo "👉 Issue #$ISSUE has $total reactions — Assigning label: $priority"
               else
-                echo "👉 Issue #$ISSUE has $total reactions — Below threshold ($FEATURE_MEDIUM), no priority label assigned"
-                continue
+                priority="Priority:2"
+                echo "👉 Issue #$ISSUE has $total reactions — Assigning label: $priority"
               fi
             else
               echo "👉 Issue #$ISSUE has no Type:Bug or Type:Feature label — Skipping prioritization"

--- a/.github/workflows/prioritize-by-reactions.yaml
+++ b/.github/workflows/prioritize-by-reactions.yaml
@@ -1,8 +1,8 @@
 name: Prioritize Issues by Reactions
 
 on:
-  schedule:
-    - cron: '0 0 * * *'   # Runs once a day at midnight UTC
+  # schedule:
+  #   - cron: '0 0 * * *'   # Runs once a day at midnight UTC
   workflow_dispatch:       # Allows manual runs
 
 jobs:


### PR DESCRIPTION
This PR roles out some new changes that aim to help triage in this repo. Below are the changes that this PR will make in the process that hopefully add more uniformity to triage and help smooth the process:

## Automated Issue Triage Workflow
### New Issue Processing
When someone opens a new issue:

* Auto-labeling: The bot will try to add a Type Label (Type:Bug, Type:Feature, or Type:CustomerSupport) based on:
    * Seeing if the issue description contains a "Type: Bug" or "Type: Feature Request" as the issues coming from VSCode have.
    * Issues coming from the issues templates will automatically have a type label applied.
    * If no type label is found:
        * Add a "needs-typeLabel" label
        * Post a comment asking the team to add the appropriate Type label
        * Note: customers will not be able to add labels themselves
     * Edit - there is now a scheduled event that will add a "needs-typeLabel" to issues that do not have a label. This should help in case a type label gets removed or for any existing issues that do not have a type label when we push this bot out.

#### Type Label Assignment
When someone adds a Type label to an issue:

* Cleanup: The bot automatically removes "Needs-typeLabel" label (since the required info was provided)

### Scheduled Cleanup (will most likely be run once a day or week but has a higher frequency while we get the changes set up in this repo)

#### Warning Phase
* Target: Issues with "Needs-Info" label that haven't had activity for 7 days
* Action: Posts warning comment and adds "Stale" label
* Protection: Won't affect issues with "DoNotClose" label

#### Closure Phase
* Target: Issues with BOTH "Needs-Info" AND "Stale" labels that haven't had activity for 7 days
* Action: Posts closure comment and closes the issue
* Protection: Won't affect issues with "DoNotClose" label

#### Long-term Cleanup
* Target: Lower priority Type:Bug and Type:CustomerSupport (no Priority:0, Priority:1, or Type:Feature labels) inactive for 18 months (548 days)
* Action: Closes with long-term inactivity message
* Protection: Won't affect issues with "DoNotClose" label

#### Testing Automation
* Testing labels: Issues with "testing" label get test replies
* Testing closure: Issues with "testing-close" label get test replies and are closed

### Key Points for CSE Team:
* DoNotClose label protects important issues from automation
* Priority:0 and Priority:1 labels protect high-priority issues from long-term cleanup
* Type labels are required - the bot will keep asking until one is assigned
* All automated actions include explanatory comments to maintain transparency

### Label Changes:
* Type:Bug <- bug
* Type:Feature <- feature-request
* Type:CustomerSupport <- Customer Support
**Note**: these changes aim to make it clear that there are three appropriate types of label for each issue. Also, we are aware that some issues have the "Types" applied of Feature, Bug, or Task, but there is not yet a way to add these labels using the GitOps tool.

## Priority Label Automation
This GitHub Actions workflow automatically assigns priority labels to issues based on community reactions (👍, ❤️, etc.).

####  When It Runs
* Eventually - Daily: Every day at midnight UTC (frequency may be changed). We will start just manual as we roll this out.
* Manual: Can be triggered manually via workflow dispatch

### How Priority Assignment Works

#### For Bug Issues (Type:Bug)
* Priority:0 (Critical): 10+ reactions
* Priority:1 (High): 5-9 reactions
* Priority:2 (Medium): 0-4 reactions

#### For Feature Requests (Type:Feature)
* Priority:1 (High): 25+ reactions
* Priority:2 (Medium): 0-24 reactions

#### Smart Label Management
* Respects Manual Changes: If a human manually sets a priority label, the automation won't override it
* Only Updates Bot Changes: Will only modify priority labels that were previously set by github-actions[bot]
* Clean Transitions: Removes old priority labels before adding new ones
* Type Requirement: Only processes issues that have Type:Bug or Type:Feature labels

#### What the Team Sees
* Issues automatically get priority labels based on community engagement
* Higher reaction counts = higher priority
* Manual priority assignments are preserved
* Bugs get prioritized faster (lower reaction thresholds) than features
* Issues without Type labels are skipped entirely

## Other overall considerations and things to expect
* There are currently 5 open issues that have the 'needs-info' label. The bot will add a 'stale' label to these with a message and then will have 1 week to receive some form of activity on the issue (customer or us) before closing the issue.
* Any issues that have not had any activity for over 18 months will be closed (aside issues marked with either "Type:Feature", "Priority:0", "Priority:1" or"DoNotClose".
* The best way to be sure the bot does not touch an issue is to add the 'DoNotClose' label
* We will have 2 test issues added to the issues that will be titled 'Github Triage Bot Test' if you can leave those untouched while we onboard this bot.
* Our priority labeler will add labels to these issues which counts as activity on the issues. 
* Changing the name or color of existing labels does not count as activity on the issues