### PR TITLE
Add rule that updates 'needs-info' issues after the customer responds

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -115,6 +115,7 @@ configuration:
               hour: 1
         filters:
           - isOpen
+          - isIssue
           - noActivitySince:
               days: 7
           - hasLabel:
@@ -133,6 +134,7 @@ configuration:
               hour: 1
         filters:
           - isOpen
+          - isIssue
           - noActivitySince:
               days: 7
           - hasLabel:
@@ -154,6 +156,7 @@ configuration:
               hour: 1
         filters:
           - isOpen
+          - isIssue
           - noActivitySince:
               days: 548
           - isNotLabeledWith:
@@ -174,6 +177,7 @@ configuration:
               hour: 1
         filters:
           - isOpen
+          - isIssue
           - isNotLabeledWith:
               label: Type:Bug
           - isNotLabeledWith:
@@ -193,6 +197,7 @@ configuration:
               hour: 1
         filters:
           - isOpen
+          - isIssue
           - hasLabel:
               label: testing
         actions:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -90,6 +90,24 @@ configuration:
             then:
               - removeLabel:
                   label: needs-typeLabel
+      - description: Add 'customerResponded' label to issues that are 'needs-info' and have received a comment from the issue author
+        triggerOnOwnActions: false
+        if:
+          - payloadType: Issue_Comment
+          - isOpen
+          - hasLabel:
+              label: needs-info
+          - isActivitySender:
+              issueAuthor: true
+        then:
+          - addLabel:
+              label: customerResponded
+          - if:
+              - hasLabel:
+                  label: Stale
+            then:
+              - removeLabel:
+                  label: Stale
     scheduledSearches:
       - description: Close issues that are 'needs-info' and 'Stale', and have not received any activity for 1 week
         frequencies:
@@ -120,9 +138,11 @@ configuration:
           - hasLabel:
               label: needs-info
           - isNotLabeledWith:
-              label: DoNotClose
+              label: customerResponded
           - isNotLabeledWith:
               label: Stale
+          - isNotLabeledWith:
+              label: DoNotClose
         actions:
           - addReply:
               reply: "${issueAuthor}, this issue will be closed soon due to inactivity. Please add more information to help us triage this issue."
@@ -145,9 +165,9 @@ configuration:
           - isNotLabeledWith:
               label: DoNotClose
         actions:
-          - closeIssue
           - addReply:
               reply: "${issueAuthor}, this issue has been closed due to inactivity for 18 months. Please feel free to reopen it if you have further information or questions."
+          - closeIssue
       - description: Add 'needs-typeLabel' to existing issues that do not have a Type label
         frequencies:
           - hourly:
@@ -163,10 +183,10 @@ configuration:
           - isNotLabeledWith:
               label: needs-typeLabel
         actions:
-          - addLabel:
-              label: needs-typeLabel
           - addReply:
               reply: 'Team, please add a `Type:Bug`/`Type:Feature`/`Type:CustomerSupport` label as applicable.'
+          - addLabel:
+              label: needs-typeLabel
       - description: TEST - Reply to every testing issue
         frequencies:
           - hourly:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -191,29 +191,5 @@ configuration:
               reply: 'Team, please add a `Type:Bug`/`Type:Feature`/`Type:CustomerSupport` label as applicable.'
           - addLabel:
               label: needs-typeLabel
-      - description: TEST - Reply to every testing issue
-        frequencies:
-          - hourly:
-              hour: 1
-        filters:
-          - isOpen
-          - isIssue
-          - hasLabel:
-              label: testing
-        actions:
-          - addReply:
-              reply: "TEST - Scheduled runs work"
-      - description: TEST - reply to test issue and close
-        frequencies:
-          - hourly:
-              hour: 1
-        filters:
-          - isOpen
-          - hasLabel:
-              label: testing-close
-        actions:
-          - addReply:
-              reply: "TEST - Scheduled runs works and can close issues"
-          - closeIssue
 onFailure:
 onSuccess:

--- a/.github/workflows/prioritize-by-reactions.yaml
+++ b/.github/workflows/prioritize-by-reactions.yaml
@@ -1,8 +1,8 @@
 name: Prioritize Issues by Reactions
 
 on:
-  # schedule:
-  #   - cron: '0 0 * * *'   # Runs once a day at midnight UTC
+  schedule:
+    - cron: '0 0 * * *'   # Runs once a day at midnight UTC
   workflow_dispatch:       # Allows manual runs
 
 jobs:

--- a/.github/workflows/prioritize-by-reactions.yaml
+++ b/.github/workflows/prioritize-by-reactions.yaml
@@ -1,8 +1,8 @@
 name: Prioritize Issues by Reactions
 
 on:
-  schedule:
-    - cron: '0 0 * * *'   # Runs once a day at midnight UTC
+  # schedule:
+  #   - cron: '0 0 * * *'   # Runs once a day at midnight UTC
   workflow_dispatch:       # Allows manual runs
 
 jobs:


### PR DESCRIPTION
2 changes:

1. Add 'isIssue' check to rules so that it doesn't act on Pull Requests
2. If a customer responds to a 'needs-info' issue, we need to make sure we don't close it by mistake.
    - We'll now remove the 'stale' label if it exists, and add a 'customerResponded' label for CSEs to track. If an issue has 'customerResponded', it won't be closed like other stale issues. It waits for the CSEs to take a look and update the state of the issue.

**NEW FLOW FOR CSE TEAM:**

If a 'needs-info' issue also has 'customerResponded', then
 - If the author did not provide all the information we asked for, and we continue to need information from them, go ahead and **remove that 'customerResponded' label**. Keep the 'needs-info' label on the issue.
 - If we got the info we need, then **remove the 'needs-info' label and the 'customerResponded' label**